### PR TITLE
Migrate from DigitalOcean to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -6,9 +6,8 @@ on:
       - release/*
 
 env:
-  REGISTRY: registry.digitalocean.com
-  REGISTRY_NAMESPACE: ${{ vars.DOCR_REGISTRY }}
-  IMAGE_NAME: ${{ github.event.repository.name }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -26,13 +25,12 @@ jobs:
         with:
           driver: docker-container
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-
-      - name: Log in to DigitalOcean Container Registry
-        run: doctl registry login --expiry-seconds 600
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine deployment tag
         id: vars
@@ -50,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build
@@ -58,7 +56,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
- Change registry from registry.digitalocean.com to ghcr.io
- Replace doctl authentication with docker/login-action using GITHUB_TOKEN
- Update image name format to use github.repository (owner/repo)
- Remove DOCR_REGISTRY and DIGITALOCEAN_ACCESS_TOKEN dependencies

https://claude.ai/code/session_012QW1XTSCJpnWCaDGwSAeNg