### PR TITLE
feat: add Docker Compose support and fix remote server entry point

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  calendar-mcp:
+    build: .
+    container_name: calendar-mcp
+    restart: always
+    ports:
+      - "8080:8080"
+    environment:
+      # iCalendar Feed Configuration (JSON array)
+      # REQUIRED: At least one calendar feed must be configured
+      - ICAL_FEED_CONFIGS=${ICAL_FEED_CONFIGS:-[{"name":"Example","url":"https://example.com/calendar.ics"}]}
+      
+      # Timezone for calendar events and current time (IANA timezone name)
+      - TIMEZONE=${TIMEZONE:-UTC}
+      
+      # Refresh interval in minutes
+      - REFRESH_INTERVAL=${REFRESH_INTERVAL:-60}
+      
+      # Optional: Enable debug logging
+      - DEBUG=${DEBUG:-false}
+      
+      # Remote Server Configuration
+      - HOST=0.0.0.0
+      - PORT=8080
+      
+      # SECURITY: It is highly recommended to set an API key for production
+      # When set, the endpoint will be: http://<host>:8080/app/<key>/<hash>/mcp
+      - MCP_API_KEY=${MCP_API_KEY:-}
+      - MD5_SALT=${MD5_SALT:-}
+      
+      # Redis Cache Configuration (Optional - uncomment redis service below to use)
+      # - REDIS_HOST=redis
+      # - REDIS_SSL_PORT=6379
+      
+    # depends_on:
+    #   - redis
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/app/health').read()"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+  # Optional Redis service for improved performance
+  # redis:
+  #   image: redis:7-alpine
+  #   container_name: calendar-mcp-redis
+  #   restart: always
+  #   volumes:
+  #     - redis-data:/data
+
+# volumes:
+#   redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,14 @@ services:
     container_name: calendar-mcp
     restart: always
     ports:
-      - "8080:8080"
+      # Maps the host port (from PORT env var) to the container port 8080
+      # Note: PORT must be between 1 and 65535
+      - "${PORT:-8080}:8080"
     environment:
       # iCalendar Feed Configuration (JSON array)
-      # REQUIRED: At least one calendar feed must be configured
       - ICAL_FEED_CONFIGS=${ICAL_FEED_CONFIGS:-[{"name":"Example","url":"https://example.com/calendar.ics"}]}
       
-      # Timezone for calendar events and current time (IANA timezone name)
+      # Timezone for calendar events and current time
       - TIMEZONE=${TIMEZONE:-UTC}
       
       # Refresh interval in minutes
@@ -21,19 +22,17 @@ services:
       
       # Remote Server Configuration
       - HOST=0.0.0.0
+      # We force the app to listen on 8080 INSIDE the container to match the mapping and healthcheck
       - PORT=8080
       
       # SECURITY: It is highly recommended to set an API key for production
-      # When set, the endpoint will be: http://<host>:8080/app/<key>/<hash>/mcp
       - MCP_API_KEY=${MCP_API_KEY:-}
       - MD5_SALT=${MD5_SALT:-}
       
-      # Redis Cache Configuration (Optional - uncomment redis service below to use)
+      # Redis Cache Configuration (Optional)
       # - REDIS_HOST=redis
       # - REDIS_SSL_PORT=6379
       
-    # depends_on:
-    #   - redis
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/app/health').read()"]
       interval: 30s
@@ -41,7 +40,7 @@ services:
       retries: 3
       start_period: 5s
 
-  # Optional Redis service for improved performance
+  # Optional Redis service
   # redis:
   #   image: redis:7-alpine
   #   container_name: calendar-mcp-redis

--- a/src/server.py
+++ b/src/server.py
@@ -48,7 +48,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Initialize MCP server
-mcp = FastMCP(name="CalendarMCP", stateless_http=True)
+mcp = FastMCP(name="CalendarMCP")
 
 # Service instances (will be initialized on first use)
 _ical_service: Optional[MultiCalendarService] = None

--- a/src/server_remote.py
+++ b/src/server_remote.py
@@ -11,6 +11,9 @@ import logging
 import hashlib
 import asyncio
 from dotenv import load_dotenv
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import Response
+from starlette.middleware.base import BaseHTTPMiddleware
 
 # Load environment variables
 load_dotenv(".env.local")
@@ -53,14 +56,76 @@ def lazy_initialize_services():
     logger.info("Services initialized successfully")
 
 
+# Security middleware to add headers
+class SecurityMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+
+        # Add security headers
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Cache-Control"] = (
+            "no-store, no-cache, must-revalidate, private"
+        )
+
+        # Remove server identification headers if they exist
+        if "server" in response.headers:
+            del response.headers["server"]
+        if "x-powered-by" in response.headers:
+            del response.headers["x-powered-by"]
+
+        return response
+
+
+# Middleware to lazy-initialize services on first real request
+class LazyInitMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        # Skip lazy init for health check (keeps it fast)
+        if request.url.path != "/app/health":
+            lazy_initialize_services()
+
+        return await call_next(request)
+
+
+# Get the MCP server instance
+from .server import mcp
+
+# Get the MCP HTTP app
+mcp_app = mcp.http_app()
+
+# Create FastAPI app with security settings and MCP lifespan
+app = FastAPI(
+    title="MattasMCP Remote Server",
+    docs_url=None,  # Disable Swagger UI
+    redoc_url=None,  # Disable ReDoc
+    openapi_url=None,  # Disable OpenAPI schema
+    lifespan=mcp_app.lifespan,  # REQUIRED: Connect MCP app's lifespan
+)
+
+# Add middlewares (order matters - security first, then lazy init)
+app.add_middleware(SecurityMiddleware)
+app.add_middleware(LazyInitMiddleware)
+
+
+# Ultra-lightweight health check endpoint - no service initialization
+@app.get("/app/health")
+async def health_check():
+    """
+    Lightweight health check endpoint for container orchestrators.
+    Does NOT trigger service initialization to keep cold starts fast.
+    """
+    return {
+        "status": "healthy",
+        "initialized": _services_initialized,
+        "version": "2.0.0",
+    }
+
+
 if api_key:
     # Use path-based authentication if API key is set
     logger.info("MCP_API_KEY is set - using path-based authentication")
-
-    from fastapi import FastAPI, Request, HTTPException
-    from fastapi.responses import Response
-    from starlette.middleware.base import BaseHTTPMiddleware
-    from .server import mcp
 
     # Validate API key format (prevent path traversal attacks)
     if not api_key.replace("-", "").replace("_", "").isalnum():
@@ -74,7 +139,7 @@ if api_key:
             "API key is too short. Consider using a longer key for better security."
         )
 
-    # Calculate hash of API key with optional salt for additional security layer
+    # Calculate hash of API key with optional salt
     if md5_salt:
         logger.info("Using salt from MD5_SALT environment variable")
         hash_input = f"{md5_salt}{api_key}"
@@ -82,164 +147,61 @@ if api_key:
         logger.warning("No MD5_SALT configured - using unsalted hash")
         hash_input = api_key
 
-    # Use SHA-256 to avoid weak-hash usage
     api_key_hash = hashlib.sha256(hash_input.encode()).hexdigest()
     logger.info(
         f"API key hash calculated: {api_key_hash[:8]}... (showing first 8 chars)"
     )
 
-    # Get configuration
-    port = int(os.getenv("PORT", "8080"))
-    # Binding to all interfaces is required for container orchestration; enforce via HOST env var.
-    host = os.getenv("HOST", "0.0.0.0")  # nosec B104
-
-    # Check configuration
-    if not os.getenv("ICAL_FEED_CONFIGS"):
-        logger.warning(
-            "No iCalendar feeds configured - will initialize on first request"
-        )
-
-    # DO NOT initialize services here - lazy init on first request
-    # This allows the container to start immediately
-
-    # Security middleware to add headers
-    class SecurityMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request: Request, call_next):
-            response = await call_next(request)
-
-            # Add security headers
-            response.headers["X-Content-Type-Options"] = "nosniff"
-            response.headers["X-Frame-Options"] = "DENY"
-            response.headers["X-XSS-Protection"] = "1; mode=block"
-            response.headers["Referrer-Policy"] = "no-referrer"
-            response.headers["Cache-Control"] = (
-                "no-store, no-cache, must-revalidate, private"
-            )
-
-            # Remove server identification headers if they exist
-            if "server" in response.headers:
-                del response.headers["server"]
-            if "x-powered-by" in response.headers:
-                del response.headers["x-powered-by"]
-
-            return response
-
-    # Middleware to lazy-initialize services on first real request
-    class LazyInitMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request: Request, call_next):
-            # Skip lazy init for health check (keeps it fast)
-            if request.url.path != "/app/health":
-                lazy_initialize_services()
-
-            return await call_next(request)
-
-    # Get the MCP HTTP app without a path since we'll mount it at /mcp
-    mcp_app = mcp.http_app()
-
-    # Create FastAPI app with security settings and MCP lifespan
-    app = FastAPI(
-        title="MattasMCP Remote Server",
-        docs_url=None,  # Disable Swagger UI
-        redoc_url=None,  # Disable ReDoc
-        openapi_url=None,  # Disable OpenAPI schema
-        lifespan=mcp_app.lifespan,  # REQUIRED: Connect MCP app's lifespan
-    )
-
-    # Add middlewares (order matters - security first, then lazy init)
-    app.add_middleware(SecurityMiddleware)
-    app.add_middleware(LazyInitMiddleware)
-
-    # Ultra-lightweight health check endpoint - no service initialization
-    # This endpoint MUST be fast to pass health checks during cold starts
-    @app.get("/app/health")
-    async def health_check():
-        """
-        Lightweight health check endpoint for container orchestrators.
-        Does NOT trigger service initialization to keep cold starts fast.
-        """
-        return {
-            "status": "healthy",
-            "initialized": _services_initialized,
-            "version": "2.0.0",
-        }
-
     # Mount the MCP app at /app/{api_key}/{api_key_hash}
-    # The MCP app has internal routes like /mcp, /sse, etc.
     app.mount(f"/app/{api_key}/{api_key_hash}", mcp_app)
 
     # Add a custom 404 handler with anti-brute-force delay
     @app.exception_handler(404)
     async def not_found_handler(request: Request, exc: HTTPException):
-        # Add 30-second delay for failed authentication attempts to prevent brute forcing
-        # Only delay for /app/ paths that look like authentication attempts
         if request.url.path.startswith("/app/") and request.url.path != "/app/health":
             logger.warning(
                 f"Invalid authentication path attempted: {request.url.path} from {request.client.host if request.client else 'unknown'}"
             )
             await asyncio.sleep(30)
-
-        # Return an empty 404 so any upstream (e.g. reverse proxy)
-        # can render its own 404 page.
         return Response(status_code=404)
-
-    if __name__ == "__main__":
-        # When run directly (not via uvicorn CLI)
-        import uvicorn
-
-        logger.info(
-            "Starting MattasMCP remote server with dual-factor path authentication"
-        )
-        logger.info(
-            f"MCP endpoint: http://{host}:{port}/app/{api_key}/{api_key_hash}/mcp"
-        )
-        logger.info(f"Health check (public): http://{host}:{port}/app/health")
-        logger.info(f"API Key Hash: {api_key_hash}")
-        logger.warning("Keep your API key secret and use HTTPS in production!")
-        logger.info("Services will initialize lazily on first MCP request")
-
-        uvicorn.run(
-            app,
-            host=host,
-            port=port,
-            loop="uvloop",  # Use uvloop for better performance
-            http="httptools",  # Use httptools for faster HTTP parsing
-            log_level="warning",
-            access_log=False,  # Disable access logs to prevent API key leakage
-            server_header=False,
-            date_header=False,
-        )
 
 else:
     # Use simple unauthenticated mode if no API key is set
     logger.warning("MCP_API_KEY not set - running in UNAUTHENTICATED mode")
     logger.warning("This is not recommended for production use!")
 
-    from .server import mcp
+    # Mount the MCP app at the root /mcp
+    app.mount("/", mcp_app)
 
-    # DO NOT initialize services here - lazy init on first request
+if __name__ == "__main__":
+    import uvicorn
 
-    # For unauthenticated mode, we still use the mcp.run() method
-    # but we should avoid eager initialization
-    if __name__ == "__main__":
-        # Get configuration
-        port = int(os.getenv("PORT", "8080"))
-        # Binding to all interfaces is required for container orchestration; enforce via HOST env var.
-        host = os.getenv("HOST", "0.0.0.0")  # nosec B104
+    # Get configuration
+    port = int(os.getenv("PORT", "8080"))
+    host = os.getenv("HOST", "0.0.0.0")
 
-        # Check configuration
-        if not os.getenv("ICAL_FEED_CONFIGS"):
-            logger.warning(
-                "No iCalendar feeds configured - will initialize on first request"
-            )
-
-        # For unauthenticated mode, let FastMCP handle everything
-        # FastMCP will initialize services when needed
+    if api_key:
+        logger.info(
+            "Starting MattasMCP remote server with dual-factor path authentication"
+        )
+        logger.info(
+            f"MCP endpoint: http://{host}:{port}/app/{api_key}/{api_key_hash}/mcp"
+        )
+    else:
         logger.info("Starting MattasMCP remote server (UNAUTHENTICATED)")
         logger.info(f"MCP endpoint: http://{host}:{port}/mcp")
-        logger.info(
-            "Note: Set MCP_API_KEY environment variable to enable authentication"
-        )
-        logger.info("Services will initialize lazily on first MCP request")
 
-        # Start the server with HTTP transport
-        mcp.run(transport="http", host=host, port=port)
+    logger.info(f"Health check (public): http://{host}:{port}/app/health")
+    logger.info("Services will initialize lazily on first MCP request")
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        loop="uvloop",
+        http="httptools",
+        log_level="warning",
+        access_log=False,
+        server_header=False,
+        date_header=False,
+    )

--- a/src/server_remote.py
+++ b/src/server_remote.py
@@ -92,8 +92,8 @@ class LazyInitMiddleware(BaseHTTPMiddleware):
 # Get the MCP server instance
 from .server import mcp
 
-# Get the MCP HTTP app
-mcp_app = mcp.http_app()
+# Get the MCP HTTP app with stateless mode enabled
+mcp_app = mcp.http_app(stateless_http=True)
 
 # Create FastAPI app with security settings and MCP lifespan
 app = FastAPI(

--- a/src/services/ical.py
+++ b/src/services/ical.py
@@ -1,6 +1,8 @@
 """Service for fetching and caching multiple named iCalendar feeds"""
 
 import logging
+import os
+from zoneinfo import ZoneInfo
 from datetime import datetime, timedelta, date
 from typing import Dict, List, Optional, Any
 from threading import Lock, Timer
@@ -67,6 +69,17 @@ class MultiCalendarService:
         self._refresh_timer: Optional[Timer] = None
         self.mcp = mcp
         self.cache = cache
+
+        # Get timezone configuration
+        self.timezone_str = os.getenv("TIMEZONE", "UTC")
+        try:
+            self.tz = ZoneInfo(self.timezone_str)
+        except Exception as e:
+            logger.warning(
+                f"Invalid timezone '{self.timezone_str}': {e}. Falling back to UTC."
+            )
+            self.tz = ZoneInfo("UTC")
+            self.timezone_str = "UTC"
 
         # Initialize feeds
         for config in feed_configs:
@@ -216,7 +229,7 @@ class MultiCalendarService:
 
                 calendar = Calendar.from_ical(response.content)
                 feed.calendar = calendar
-                feed.last_fetch = datetime.now(UTC)
+                feed.last_fetch = datetime.now(self.tz)
                 feed.error = None
 
                 event_count = sum(
@@ -493,7 +506,7 @@ class MultiCalendarService:
         if start_date:
             start_dt = self._normalize_datetime(start_date)
         else:
-            start_dt = datetime.now(UTC)
+            start_dt = datetime.now(self.tz)
 
         if end_date:
             end_dt = self._normalize_datetime(end_date)
@@ -562,12 +575,14 @@ class MultiCalendarService:
         self, feed_identifiers: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         """Get events for today from specified feeds or all feeds"""
-        today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-        tomorrow = today + timedelta(days=1)
+        # Calculate 'today' based on the configured local timezone
+        now_local = datetime.now(self.tz)
+        today_start = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        tomorrow_start = today_start + timedelta(days=1)
 
         return self.get_events(
-            start_date=today.isoformat(),
-            end_date=tomorrow.isoformat(),
+            start_date=today_start.isoformat(),
+            end_date=tomorrow_start.isoformat(),
             feed_identifiers=feed_identifiers,
         )
 
@@ -575,7 +590,7 @@ class MultiCalendarService:
         self, count: int = 10, feed_identifiers: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         """Get upcoming events from specified feeds or all feeds"""
-        now = datetime.now(UTC)
+        now = datetime.now(self.tz)
         future_events = []
 
         feeds_to_query = []
@@ -1407,7 +1422,7 @@ Events matching the search query in:
 
     def get_week_events_resource(self) -> Dict[str, Any]:
         """Get all events for the current week"""
-        now = datetime.now(UTC)
+        now = datetime.now(self.tz)
         # Get start of week (Monday)
         start_of_week = now - timedelta(days=now.weekday())
         start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1427,7 +1442,7 @@ Events matching the search query in:
 
     def get_month_events_resource(self) -> Dict[str, Any]:
         """Get all events for the current month"""
-        now = datetime.now(UTC)
+        now = datetime.now(self.tz)
         # Get first day of month
         start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         # Get first day of next month
@@ -1450,7 +1465,7 @@ Events matching the search query in:
 
     def get_tomorrow_events_resource(self) -> Dict[str, Any]:
         """Get all events for tomorrow"""
-        today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        today = datetime.now(self.tz).replace(hour=0, minute=0, second=0, microsecond=0)
         tomorrow = today + timedelta(days=1)
         day_after = tomorrow + timedelta(days=1)
 
@@ -1470,7 +1485,7 @@ Events matching the search query in:
         Args:
             include_all_day: Whether to include all-day events in conflict detection
         """
-        now = datetime.now(UTC)
+        now = datetime.now(self.tz)
         week_later = now + timedelta(days=7)
 
         events = self.get_events(
@@ -1552,7 +1567,7 @@ Events matching the search query in:
         Returns:
             Detailed conflict analysis with severity levels and statistics
         """
-        now = datetime.now(UTC)
+        now = datetime.now(self.tz)
         end_date = now + timedelta(days=days_ahead)
 
         events = self.get_events(
@@ -1622,7 +1637,7 @@ Events matching the search query in:
                 "start": now.isoformat(),
                 "end": end_date.isoformat(),
                 "days": days_ahead,
-                "timezone": "UTC",
+                "timezone": self.timezone_str,
             },
             "filters": {
                 "include_all_day": include_all_day,

--- a/src/services/ical.py
+++ b/src/services/ical.py
@@ -336,11 +336,11 @@ class MultiCalendarService:
             if hasattr(value, "dt"):
                 dt = value.dt
                 if isinstance(dt, datetime):
-                    # Normalize to UTC before serializing
+                    # Convert to local timezone before serializing
                     if dt.tzinfo is None:
-                        dt = dt.replace(tzinfo=UTC)
+                        dt = dt.replace(tzinfo=UTC).astimezone(self.tz)
                     else:
-                        dt = dt.astimezone(UTC)
+                        dt = dt.astimezone(self.tz)
                     return dt.isoformat()
                 else:
                     return dt.isoformat() if hasattr(dt, "isoformat") else str(dt)
@@ -357,7 +357,7 @@ class MultiCalendarService:
                 if hasattr(dtstart, "dt"):
                     start_dt = dtstart.dt
                     if hasattr(duration, "dt"):
-                        # Normalize start time to UTC first
+                        # Normalize start time to UTC first for calculation
                         if isinstance(start_dt, datetime):
                             if start_dt.tzinfo is None:
                                 start_dt = start_dt.replace(tzinfo=UTC)
@@ -381,7 +381,7 @@ class MultiCalendarService:
                 if hasattr(dtstart, "dt"):
                     start_dt = dtstart.dt
                     if isinstance(start_dt, datetime):
-                        # Normalize start time to UTC first
+                        # Normalize start time to UTC first for calculation
                         if start_dt.tzinfo is None:
                             start_dt = start_dt.replace(tzinfo=UTC)
                         else:


### PR DESCRIPTION
This PR adds a `docker-compose.yml` file for easier deployment (e.g., in Portainer) and fixes several critical issues related to remote deployment and timezone handling.

### Changes:
- **`docker-compose.yml`**: Added a standard compose file with environment variable interpolation for host port mapping and an optional Redis service.
- **Full Timezone Support**: 
  - Refactored `src/services/ical.py` to respect the `TIMEZONE` environment variable for all internal date calculations ("now", "today", etc.).
  - Updated event serialization to convert timestamps to the configured local timezone (e.g., `America/Chicago`) before returning them to the agent. This prevents confusion caused by UTC timestamps (e.g., `+00:00`).
- **`src/server_remote.py`**: 
  - Fixed initialization logic to ensure the FastAPI `app` is always defined.
  - Ensured the `/app/health` endpoint is available in both authenticated and unauthenticated modes.
  - Streamlined the middleware and mounting logic.
  - Updated to pass `stateless_http=True` to `mcp.http_app()` to fix a compatibility crash.
- **`src/server.py`**: Removed the deprecated `stateless_http` argument from the `FastMCP` constructor.
- **Port Mapping**: The `docker-compose.yml` now supports a `PORT` environment variable for the host-side mapping while maintaining a consistent internal port for health checks.