### PR TITLE
ci: build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,26 +4,40 @@ on:
   push:
     branches:
       - release/*
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Prepare platform pair
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -32,34 +46,88 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine deployment tag
-        id: vars
-        shell: bash
-        run: |
-          ref="${GITHUB_REF_NAME}"
-          if [ "$ref" = "release/latest" ]; then
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          else
-            tag="${ref#release/}"
-            echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
-      - name: Image digest
-        run: echo "Image pushed with digest ${{ steps.build.outputs.digest }}"
+      - name: Export digest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Determine deployment tag
+        id: vars
+        shell: bash
+        env:
+          REF: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$REF" = "release/latest" ]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "$REF" == release/* ]]; then
+            echo "tag=${REF#release/}" >> "$GITHUB_OUTPUT"
+          else
+            safe_ref="${REF//\//-}"
+            echo "tag=${safe_ref}-${SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        shell: bash
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        shell: bash
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${TAG}"


### PR DESCRIPTION
## Summary

- Split the Docker build into a matrix that builds each architecture on its native GitHub runner (`ubuntu-24.04` for amd64, `ubuntu-24.04-arm` for arm64)
- Each variant is pushed by digest, then a final `merge` job combines them into a single multi-arch manifest and tags it
- Preserves the existing tag strategy (`release/latest` → `latest`, `release/X` → `X`)
- Adds `workflow_dispatch` so the workflow can be manually triggered after merge to validate on both architectures
- All `run:` steps refactored to use `env:` vars rather than inline `${{ }}` expansion (workflow injection hardening)

## Why

Part of the GKE → AKS migration. Target cluster will use Azure `B4ps_v2` (Arm) nodes, so every image deployed to it must be multi-arch or the pod pull fails with `exec format error`. This is one of 6 repos getting the same treatment.

## Test plan

- [ ] PR CI passes (lint/format)
- [ ] After merge, manually trigger via \`gh workflow run docker-build-push.yml\` (or push to \`release/latest\`) and confirm both matrix legs succeed
- [ ] Run \`docker buildx imagetools inspect ghcr.io/amattas/calendar-mcp:latest\` and verify both \`linux/amd64\` and \`linux/arm64\` appear in the manifest